### PR TITLE
fix recording bug when using both platforms

### DIFF
--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -37,6 +37,11 @@ class Device
     @config_caps = config_caps
     @case_caps = case_caps
     @options = options
+    @driver = nil
+  end
+
+  def get_driver_tr
+    @driver
   end
 
   # assemble the full capabilities for the device,
@@ -267,7 +272,7 @@ class Device
                                           !res
       video_type = action["Video_Type"] ? action["Video_Type"] : "h264"
       if @platform == "iOS"
-        log_info("Video configuration: video_type -> #{video_type}, " +
+        log_info("#{@role}: Video configuration: video_type -> #{video_type}, " +
         "video_fps -> #{fps}, video_quality -> #{video_quality}")
         timeout = action["Time"] ? action["Time"] : "260"
         @driver.start_recording_screen(
@@ -285,12 +290,12 @@ class Device
         if !res.include?("x")
           log_info("resolution format is wrong: #{res}. " +
                  "Should be: [width]x[height]") if !res.include?("x")
-          log_info("Starting recording with default resolution, time_limit: #{timeout}, bit_rate: #{bitrate}")
+          log_info("#{@role}: Starting recording with default resolution, time_limit: #{timeout}, bit_rate: #{bitrate}")
 
-          @driver.start_recording_screen time_limit: timeout, bit_rate: bitrate
+          @driver.start_recording_screen_a time_limit: timeout, bit_rate: bitrate
         else
-          log_info("Starting recording with #{res} resolution, time_limit: #{timeout}, bit_rate: #{bitrate}")
-          @driver.start_recording_screen(
+          log_info("#{@role}: Starting recording with #{res} resolution, time_limit: #{timeout}, bit_rate: #{bitrate}")
+          @driver.start_recording_screen_a(
             video_size: "#{res}",
             time_limit: timeout,
             bit_rate: bitrate,
@@ -298,7 +303,7 @@ class Device
         end
       else
         log_info("Starting recording with default resolution, time_limit: #{timeout}, bit_rate: #{bitrate}")
-        @driver.start_recording_screen time_limit: timeout, bit_rate: bitrate
+        @driver.start_recording_screen_a(time_limit: timeout, bit_rate: bitrate) 
       end
     else
       video_quality = action["Video_Quality"] ?

--- a/lib/core/device_handler.rb
+++ b/lib/core/device_handler.rb
@@ -34,8 +34,8 @@ class DeviceHandler
         else
           @devices[case_role]       = device
         end
-        @server_port += 1
-        @driver_port += 1
+        @server_port += 2
+        @driver_port += 2
       end
     end
 
@@ -150,6 +150,7 @@ class DeviceHandler
   # Launch Appium drivers for all roles using them
   # (roles with Selenium drivers already have the drivers launched)
   def start_drivers
+    Android.initialise_appium_commands
     begin
       retries ||= 1
       threads = []


### PR DESCRIPTION
When creating two drivers for android and ios then the latest to be created will overwrite the methods of the other. When thay have shared naming pattern:

```
 module Device
          module Screen
            def self.add_methods
              ::Appium::Core::Device.add_endpoint_method(:start_recording_screen) do
                def start_recording_screen(remote_path: nil, user: nil, pass: nil, method: 'PUT',
                                           file_field_name: nil, form_fields: nil, headers: nil, force_restart: nil,
                                           video_type: 'mjpeg', time_limit: '180', video_quality: nil,
                                           video_fps: nil, video_scale: nil, video_filters: nil, pixel_format: nil)
                  option = ::Appium::Core::Base::Device::ScreenRecord.new(
                    remote_path: remote_path, user: user, pass: pass, method: method,
                    file_field_name: file_field_name, form_fields: form_fields, headers: headers,
                    force_restart: force_restart
                  ).upload_option

                  option[:videoType] = video_type
                  option[:timeLimit] = time_limit

                  option[:videoQuality] = video_quality unless video_quality.nil?
                  option[:videoFps] = video_fps unless video_fps.nil?
                  option[:videoScale] = video_scale unless video_scale.nil?
                  option[:videoFilters] = video_filters unless video_filters.nil?
                  option[:pixelFormat] = pixel_format unless pixel_format.nil?

                  execute(:start_recording_screen, {}, { options: option })
                end
              end
            end
          end # module
```
          
That method is defined in `appium_lib_core/ios/xcuitest/device/screen.rb` and also under `appium_lib_core/android/device/screen.rb`