### PR TITLE
add selenium method to get source

### DIFF
--- a/examples/tests/cases/case_selenium.yaml
+++ b/examples/tests/cases/case_selenium.yaml
@@ -30,3 +30,12 @@ TestSwitchFrameId:
       Id: "intercom-frame"
     - Type: switch_frame
       Value: "intercom-frame"
+
+TestGetSource:
+  Roles:
+    - Role: desktopChrome
+      App: desktop
+  Actions:
+    - Type: navigate
+      Value: https://www.testdevlab.com/
+    - Type: get_source

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -835,7 +835,12 @@ class Device
 
   # parses and saves the source code for currect page.
   def get_source(action)
-    source = @driver.get_source
+    source = nil
+    begin
+      source = @driver.get_source
+    rescue => e 
+      source = @driver.page_source
+    end
     File.write("./page_source.xml", source)
   end
 


### PR DESCRIPTION
The get_source method was only implemented for Appium, but for selenium is page_source. This fixes that issue