### PR TITLE
config_caps + control_flow update

### DIFF
--- a/lib/core/device_handler.rb
+++ b/lib/core/device_handler.rb
@@ -5,7 +5,7 @@ class DeviceHandler
 
   def initialize(case_role_sets)
     @timeout = $config["Timeout"] ? $config["Timeout"] : 10
-    @server_port = 4727
+    @server_port = ENV.has_key?('serverPort') ? ENV['serverPort'].to_i : 4727
     @driver_port = 8205
     @devices = {}
     create_devices(case_role_sets)
@@ -85,11 +85,13 @@ class DeviceHandler
       log_info("Role '#{case_role}': Adding capabilities from config: #{config_caps}")
       udid = config_caps["udid"] if config_caps.key?("udid")
       @driver_port = config_caps["systemPort"].to_i if config_caps.key?("systemPort")
-      @server_port = config_caps["wdaLocalPort"].to_i if config_caps.key?("wdaLocalPort")
+      @driver_port = config_caps["wdaLocalPort"].to_i if config_caps.key?("wdaLocalPort")
     end
     if !case_caps.empty?
       log_info("Role '#{case_role}': Adding capabilities from case: #{case_caps}")
       udid = case_caps["udid"] if case_caps.key?("udid")
+      @driver_port = case_caps["systemPort"].to_i if case_caps.key?("systemPort")
+      @driver_port = case_caps["wdaLocalPort"].to_i if case_caps.key?("wdaLocalPort")
     end
 
     # Create virtual device for the role

--- a/lib/core/device_handler.rb
+++ b/lib/core/device_handler.rb
@@ -84,6 +84,8 @@ class DeviceHandler
       config_caps = convert_yaml(config_device["capabilities"])
       log_info("Role '#{case_role}': Adding capabilities from config: #{config_caps}")
       udid = config_caps["udid"] if config_caps.key?("udid")
+      @driver_port = config_caps["systemPort"].to_i if config_caps.key?("systemPort")
+      @server_port = config_caps["wdaLocalPort"].to_i if config_caps.key?("wdaLocalPort")
     end
     if !case_caps.empty?
       log_info("Role '#{case_role}': Adding capabilities from case: #{case_caps}")

--- a/lib/core/device_handler.rb
+++ b/lib/core/device_handler.rb
@@ -5,7 +5,7 @@ class DeviceHandler
 
   def initialize(case_role_sets)
     @timeout = $config["Timeout"] ? $config["Timeout"] : 10
-    @server_port = ENV.has_key?('serverPort') ? ENV['serverPort'].to_i : 4727
+    @server_port = 4727
     @driver_port = 8205
     @devices = {}
     create_devices(case_role_sets)
@@ -79,6 +79,7 @@ class DeviceHandler
     url, udid, options = setup_path_to_device(config_device)
 
     # Get capabilities from config and case, and replace existing udid if it is provided
+    @server_port = convert_value(config_device["serverPort"]).to_i if config_device.key?("serverPort")
     config_caps = {}
     if config_device.key?("capabilities") && !config_device["capabilities"].nil?
       config_caps = convert_yaml(config_device["capabilities"])

--- a/lib/core/types_control_flow.rb
+++ b/lib/core/types_control_flow.rb
@@ -2,13 +2,13 @@
 module ControlFlowTypes
   # execute a case
   def case_handler(action, _case)
-    run(action["Value"], get_parent_params(action))
-    log_info("Finished case #{action["Value"]}, resuming parent case #{_case}")
+    run(convert_value(action["Value"]), get_parent_params(action))
+    log_info("Finished case #{convert_value(action["Value"])}, resuming parent case #{_case}")
   end
 
   # execute a case that can be run in parallel with another case
   def parallel_case_handler(action, case_threads, max_parallel_cases)
-    case_name = action["Value"]
+    case_name = convert_value(action["Value"])
     unless case_threads.empty?
       alive_threads = case_threads.keys.each.map {|t| t.alive?}.length
       if max_parallel_cases <= alive_threads


### PR DESCRIPTION
With the help of @TDL-EdgarsEglitis now it is possible to pass:
1) vars as value under Type: case;
2) driver_port from config_caps, overwriting default hardcoded values for parallel testing;
3) server_port from ENV var with "serverPort" key.