### PR TITLE
fix for running on apple simulators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /doc/
 /spec/reports/
 /tmp/
+examples/tests/appium_logs/
 node_modules
 pkg
 Reports

--- a/examples/tests/cases/case_ios_tests.yaml
+++ b/examples/tests/cases/case_ios_tests.yaml
@@ -1,0 +1,10 @@
+# CALL ONLY THESE METHODS
+
+iOSTestExample:
+  Roles:
+    - Role: localiOS
+      App: Settings
+  Actions:
+    - Type: click
+      Strategy: accessibility_id
+      Id: Developer

--- a/examples/tests/cases/config.yaml
+++ b/examples/tests/cases/config.yaml
@@ -4,6 +4,8 @@ Apps:
   PlayStore:
     Package: com.android.vending
     Activity: com.android.vending.AssetBrowserActivity
+  Settings:
+    iOSBundle: com.apple.Preferences
 
 chromeDriverPath: chromedriver
 
@@ -24,6 +26,9 @@ Devices:
   # ANDROID
   - role: localAndroid
     platform: Android
+  # IOS
+  - role: localiOS
+    platform: iOS
 
 #VARS
 

--- a/lib/platforms/ios.rb
+++ b/lib/platforms/ios.rb
@@ -7,11 +7,10 @@ class Ios
     idevices = `xcrun xctrace list devices 2>&1`
     log_abort "Xcode is not installed or configured!" if idevices.include?("error")
     idevices.split("\n").each do |device|
-      break if device.include?("Simulator")
       next unless device.include?(") (")
       device_list = device.split("(")
       name = device_list[0].strip
-      udid = device_list[2].split(")")[0]
+      udid = device_list.last().split(")")[0]
       devices.append([name, udid])
     end
     return devices


### PR DESCRIPTION
Right now the implementation of TestRay requires that the iOS devices should be real ones, and it doesn't let run in simulators.

With this fix it allows to run on simulators, and it also fixes a bug related to using parenthesis on the name of the devices.