### PR TITLE
fix url base path for appium 2.x version

### DIFF
--- a/lib/core/appium_server.rb
+++ b/lib/core/appium_server.rb
@@ -21,7 +21,7 @@ class AppiumServer
       opened = `netstat -anp tcp | #{grep_cmd} "#{@port}"`.include?("LISTEN")
     end
 
-    spawn("appium -p #{@port} >> #{folder}/#{@udid}.log 2>&1")
+    spawn("appium --base-path=/wd/hub -p #{@port} >> #{folder}/#{@udid}.log 2>&1")
 
     opened = false
     log_info("Role '#{@role}': Starting Appium server on port #{@port} ", no_date=false, _print=true)


### PR DESCRIPTION
In order to be able work with appium 1.X and 2.X the best option is to add the base path, this way we can have backwards compatibility.