### PR TITLE
fix: remove app management methods without app ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,13 +695,13 @@ Closes the app and leaves it running in the background.
 
     - Type: launch_app
       Role: role1
-      Value: com.android.vending (Optional - Android app package / iOS bundle ID)
+      Value: com.android.vending (Android app package / iOS bundle ID)
 
 ### <a id="terminate_app"></a>terminate_app
 
     - Type: terminate_app
       Role: role1
-      Value: com.apple.Preferences (Optional - Android app package / iOS bundle ID)
+      Value: com.apple.Preferences (Android app package / iOS bundle ID)
 
 ### <a id="start_record/end_record"></a>start_record/end_record (Mobile)
 

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -250,7 +250,7 @@ class Device
   # launches the app specified by the Android app package / iOS bundle ID
   # defaults to the app under test if Value is not provided
   # Accepts:
-  #   Value (optional)
+  #   Value
   def launch_app(action)
     raise "Application identifier is required!" unless action.key?("Value")
     app_id = action["Value"]
@@ -264,7 +264,7 @@ class Device
   # closes the app specified by the Android app package / iOS bundle ID
   # defaults to the app under test if Value is not provided
   # Accepts:
-  #   Value (optional)
+  #   Value
   def terminate_app(action)
     raise "Application identifier is required!" unless action.key?("Value")
     app_id = action["Value"]

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -252,7 +252,7 @@ class Device
   # Accepts:
   #   Value
   def launch_app(action)
-    raise "Application identifier is required!" unless action.key?("Value")
+    raise "Please specify the application identifier in the Value field!" unless action.key?("Value")
     app_id = action["Value"]
     if @platform == "iOS"
       @driver.execute_script('mobile: launchApp', {'bundleId': app_id})
@@ -266,7 +266,7 @@ class Device
   # Accepts:
   #   Value
   def terminate_app(action)
-    raise "Application identifier is required!" unless action.key?("Value")
+    raise "Please specify the application identifier in the Value field!" unless action.key?("Value")
     app_id = action["Value"]
     if @platform == "iOS"
       @driver.execute_script('mobile: terminateApp', {'bundleId': app_id})

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -252,15 +252,12 @@ class Device
   # Accepts:
   #   Value (optional)
   def launch_app(action)
+    raise "Application identifier is required!" unless action.key?("Value")
     app_id = action["Value"]
-    if app_id
-      if @platform == "iOS"
-        @driver.execute_script('mobile: launchApp', {'bundleId': app_id})
-      elsif @platform == "Android"
-        @driver.activate_app(app_id)
-      end
-    else
-      @driver.launch_app
+    if @platform == "iOS"
+      @driver.execute_script('mobile: launchApp', {'bundleId': app_id})
+    elsif @platform == "Android"
+      @driver.execute_script('mobile: activateApp', {'appId': app_id})
     end
   end
 
@@ -269,15 +266,12 @@ class Device
   # Accepts:
   #   Value (optional)
   def terminate_app(action)
+    raise "Application identifier is required!" unless action.key?("Value")
     app_id = action["Value"]
-    if app_id
-      if @platform == "iOS"
-        @driver.execute_script('mobile: terminateApp', {'bundleId': app_id})
-      elsif @platform == "Android"
-        @driver.terminate_app(app_id)
-      end
-    else
-      @driver.close_app
+    if @platform == "iOS"
+      @driver.execute_script('mobile: terminateApp', {'bundleId': app_id})
+    elsif @platform == "Android"
+      @driver.execute_script('mobile: terminateApp', {'appId': app_id})
     end
   end
 


### PR DESCRIPTION
Fixes #42 
Also changes the Android versions of these methods to use the execute method extension instead.