### PR TITLE
feat: support fractional offsets in click action

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ This is not a type but can be used in different Types as a Validation for the ac
 	  Id: //some/path
 	  NoRaise: false/true (Default - false -> will rise error on fail)
 
-Strategy and Id can also be provided as lists, in which case the framework will click the whichever element it finds first.
+Strategy and Id can also be provided as lists, in which case the framework will click whichever element it finds first.
 Both of these lists (Strategy/Id) must have the same size (number of elements):
 
 	- Type: click

--- a/README.md
+++ b/README.md
@@ -389,16 +389,16 @@ By default, the click action will be executed on the element midpoint (width * 0
 	  Role: role1 (Optional. if not specified will use the first one defined in the case Roles)
 	  Strategy: id/css/xpath/uiautomator/class_chain/...
 	  Id: //some/path
-    OffsetX: 50 (Translates to (0.5 * width) + 50)
-    OffsetY: -25 (Translates to (0.5 * height) - 25)
+	  OffsetX: 50 (Translates to (0.5 * width) + 50)
+	  OffsetY: -25 (Translates to (0.5 * height) - 25)
 	  NoRaise: false/true (Default - false -> will rise error on fail)
 
 	- Type: click
 	  Role: role1 (Optional. if not specified will use the first one defined in the case Roles)
 	  Strategy: id/css/xpath/uiautomator/class_chain/...
 	  Id: //some/path
-    OffsetFractionX: 0.4 (Translates to 0.5 + 0.4 = 0.9 * width)
-    OffsetFractionY: -0.2 (Translates to 0.5 - 0.2 = 0.3 * height)
+	  OffsetFractionX: 0.4 (Translates to 0.5 + 0.4 = 0.9 * width)
+	  OffsetFractionY: -0.2 (Translates to 0.5 - 0.2 = 0.3 * height)
 	  NoRaise: false/true (Default - false -> will rise error on fail)
 
 If an offset is needed only on one axis, the parameter for the other axis can be omitted. Additionally, mixing absolute and relative offsets within the same action is allowed, but if both offset types are provided for the same axis, the absolute offset takes precedence.

--- a/README.md
+++ b/README.md
@@ -370,8 +370,8 @@ This is not a type but can be used in different Types as a Validation for the ac
 	  Id: //some/path
 	  NoRaise: false/true (Default - false -> will rise error on fail)
 
-Strategy and Id can by put as a list, in which case it will define a list of elements, and the first one to be clickable will be clicked.
-Both lists for Startegy and Id must have the same size (Number of elements):
+Strategy and Id can also be provided as lists, in which case the framework will click the whichever element it finds first.
+Both of these lists (Strategy/Id) must have the same size (number of elements):
 
 	- Type: click
 	  Role: role1 (Optional. if not specified will use the first one defined in the case Roles)
@@ -383,7 +383,27 @@ Both lists for Startegy and Id must have the same size (Number of elements):
 		- //some/path2
 	  NoRaise: false/true (Default - false -> will rise error on fail)
 
-It is possible to add conditions, in which case it will do the click depending on the condition to be fullfiled:
+By default, the click action will be executed on the element midpoint (width * 0.5, height * 0.5), but it is possible to add offsets. These can be either absolute (in pixels) or relative (in fractions of the element width/height):
+
+	- Type: click
+	  Role: role1 (Optional. if not specified will use the first one defined in the case Roles)
+	  Strategy: id/css/xpath/uiautomator/class_chain/...
+	  Id: //some/path
+    OffsetX: 50 (Translates to (0.5 * width) + 50)
+    OffsetY: -25 (Translates to (0.5 * height) - 25)
+	  NoRaise: false/true (Default - false -> will rise error on fail)
+
+	- Type: click
+	  Role: role1 (Optional. if not specified will use the first one defined in the case Roles)
+	  Strategy: id/css/xpath/uiautomator/class_chain/...
+	  Id: //some/path
+    OffsetFractionX: 0.4 (Translates to 0.5 + 0.4 = 0.9 * width)
+    OffsetFractionY: -0.2 (Translates to 0.5 - 0.2 = 0.3 * height)
+	  NoRaise: false/true (Default - false -> will rise error on fail)
+
+If an offset is needed only on one axis, the parameter for the other axis can be omitted. Additionally, mixing absolute and relative offsets within the same action is allowed, but if both offset types are provided for the same axis, the absolute offset takes precedence.
+
+You can also add conditions, in which case the click action will be executed depending on the condition to be fulfilled:
 
 	- Type: click
 	  Role: role1 (Optional. if not specified will use the first one defined in the case Roles)

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -446,7 +446,7 @@ class Device
         if (action.keys & ["OffsetX", "OffsetY", "OffsetFractionX", "OffsetFractionY"]).any?
           x_offset = y_offset = 0
           x_offset = el.size.width * action["OffsetFractionX"] if action.key?("OffsetFractionX")
-          y_offset = el.size.width * action["OffsetFractionY"] if action.key?("OffsetFractionY")
+          y_offset = el.size.height * action["OffsetFractionY"] if action.key?("OffsetFractionY")
           x_offset = action["OffsetX"] if action.key?("OffsetX")
           y_offset = action["OffsetY"] if action.key?("OffsetY")
           @driver.action.move_to(el, x_offset, y_offset)

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -420,6 +420,8 @@ class Device
   #   CheckTime
   #   OffsetX
   #   OffsetY
+  #   OffsetFractionX
+  #   OffsetFractionY
   #   NoRaise
   def click(action)
     start = Time.now
@@ -441,8 +443,13 @@ class Device
         error = e
       end
       begin
-        if !(action["OffsetX"].nil? && action["OffsetY"].nil?)
-          @driver.action.move_to(el, action["OffsetX"], action["OffsetY"])
+        if (action.keys & ["OffsetX", "OffsetY", "OffsetFractionX", "OffsetFractionY"]).any?
+          x_offset = y_offset = 0
+          x_offset = el.size.width * action["OffsetFractionX"] if action.key?("OffsetFractionX")
+          y_offset = el.size.width * action["OffsetFractionY"] if action.key?("OffsetFractionY")
+          x_offset = action["OffsetX"] if action.key?("OffsetX")
+          y_offset = action["OffsetY"] if action.key?("OffsetY")
+          @driver.action.move_to(el, x_offset, y_offset)
             .click
             .perform
         else


### PR DESCRIPTION
This adds new parameters to the `click` action: `OffsetFractionX` and `OffsetFractionY`, which allow specifying a relative offset, as multipliers of the element width or height, respectively.
Additionally, it is no longer required to provide *both* `OffsetX` and `OffsetY` for absolute offsets - if only one axis is needed, the other parameter can be omitted.