### PR TITLE
feat: add command to return TestRay version

### DIFF
--- a/lib/testray.rb
+++ b/lib/testray.rb
@@ -19,6 +19,11 @@ module TestRay
       true
     end
 
+    desc "version", "Return the TestRay version"
+    def version()
+      log_info "TestRay v#{VERSION}"
+    end
+
     desc "execute_help", "help for creating an testray project"
     option :types,
            :desc => "Show Action Types",


### PR DESCRIPTION
This adds a simple method to return the TestRay version when running `testray version`.