### PR TITLE
feat: add execute_script type

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Roles are ALWAYS defined at the begining of the cases. You have to write always 
 18. [wait_for_page_to_load](#wait_for_page_to_load)
 19. [collection_visible_for](#collection_visible_for)
 20. [wait_not_visible](#wait_not_visible)
+21. [execute_script](#execute_script)
 
 ## Only Browser
 
@@ -598,6 +599,23 @@ Waits until the element specified is not visible.
       Strategy: id/css/xpath/uiautomator/class_chain/predicate
       Id: //div[contains(text(), "http")]
       Time: 10
+
+### <a id="execute_script"></a>execute_script
+
+Executes a specific script. For Selenium, the script value can be raw JavaScript, while for Appium, this can be the name of a defined driver script. Parameters can also be provided as an optional value.
+
+Example for Selenium (set a console property):
+
+    - Type: execute_script
+      Role: role1 (Optional. if not specified will use the first one defined in the case Roles)
+      Value: window.localStorage.logLevel = '0'
+
+Example for Appium (launch Chrome on Android)
+
+    - Type: execute_script
+      Role: role1 (Optional. if not specified will use the first one defined in the case Roles)
+      Value: "mobile: launchApp"
+      Params: { appId: com.android.chrome }
 
 ## Only Browser
 

--- a/lib/core/case_runner.rb
+++ b/lib/core/case_runner.rb
@@ -249,6 +249,10 @@ def log_step(role, action)
     log_info("Role: '#{role}', Action: '#{action["Type"]}', " +
     "Coords: Start -> X:'#{action["StartX"]}', Y: '#{action["StartY"]}' - " +
     "End -> X:'#{action["EndX"]}', Y: '#{action["EndY"]}'")
+  elsif action["Type"] == "execute_script" && action.key?("Params")
+    log_info("Role: '#{role}', Action: '#{action["Type"]}', " +
+    "Value: '#{convert_value(action["Value"])}', " +
+    "Params: '#{convert_value(action["Params"])}'")
   else
     if action["Strategy"] && action["Value"]
       log_info("Role: '#{role}', Action: '#{action["Type"]}', " +

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -282,6 +282,22 @@ class Device
     @driver.update_settings(convert_yaml(action["Value"]))
   end
 
+  # executes a custom script, which can be either raw JavaScript code (for browsers)
+  # or the name of a defined driver script. Parameters can also be provided
+  # Accepts:
+  #   Value
+  #   Params
+  def execute_script(action)
+    script_command = convert_value(action["Value"])
+    if action.key?("Params")
+      raw_params = action["Params"]
+      params = raw_params.is_a?(Hash) ? convert_yaml(raw_params) : convert_value(raw_params)
+      @driver.execute_script(script_command, params)
+    else
+      @driver.execute_script(script_command)
+    end
+  end
+
   # starts recording test execution. Whole desktop is recorded if 'udid' is not
   # set.
   # Accepts:


### PR DESCRIPTION
This adds the execute_script method. It applies to both Selenium and Appium drivers, and works with both implementations.