### PR TITLE
fix: fixes for scroll_until_element_visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ Set the scrolling timeout:
 	  Role: role1
 	  Strategy: id/css/xpath/uiautomator/class_chain/...
 	  Id: //some/path
-	  ScrollTimeout: 90 (In seconds - default is 60)
+	  ScrollTimeout: 90 (In seconds - default is the global timeout)
 
 Instruct the target element to be scrolled into full view. This means that once the element is visible, one additional swipe will be executed from the element location, to either the top or the bottom of the scroll target (depending on the scroll direction configured in the swipe action).
 

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -743,7 +743,7 @@ class Device
       scroll_mul /= convert_value(sw_action["SwipeSpeedMultiplier"]).to_f if sw_action.key?("SwipeSpeedMultiplier")
       scroll_pause = convert_value(sw_action["SwipePauseDuration"]).to_f if sw_action.key?("SwipePauseDuration")
     end
-    scroll_timeout = action.key?("ScrollTimeout") ? convert_value(action["ScrollTimeout"]).to_f : 60
+    scroll_timeout = action.key?("ScrollTimeout") ? convert_value(action["ScrollTimeout"]).to_f : @timeout
     # calculate the exact coordinates for swiping,
     # depending on whether a specific element to swipe on is provided
     if action.key?("ScrollTarget")

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -804,9 +804,9 @@ class Device
       bg_el = wait_for(action["ScrollTarget"])
       y_top = bg_el.location.y
       y_bottom = bg_el.location.y + bg_el.size.height
-      x_point = bg_el.location.x + (bg_el.size.width * x_frac)
-      y_start = y_top + (bg_el.size.height * y_start_frac)
-      y_end = y_top + (bg_el.size.height * y_end_frac)
+      x_point = bg_el.location.x + (bg_el.size.width * (0.5 + x_frac))
+      y_start = y_top + (bg_el.size.height * (0.5 + y_start_frac))
+      y_end = y_top + (bg_el.size.height * (0.5 + y_end_frac))
     end
     # raise error if timeout exceeded
     return if original_noraise


### PR DESCRIPTION
This fixes an issue with `scroll_until_element_visible` when using `RecheckAfterScrolls`, where the scroll positions were not correctly calculated. Related to #61.