### PR TITLE
fix: prevent click action from being skipped

### DIFF
--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -457,7 +457,7 @@ class Device
 
     wait_time = (action["CheckTime"] ? action["CheckTime"] : @timeout)
 
-    while (Time.now - after_find) < wait_time
+    loop do
       begin
         @platform == "iOS" ?
           @driver.action.move_to(el) :
@@ -483,6 +483,7 @@ class Device
       rescue => e
         error = e
       end
+      break if (Time.now - after_find) >= wait_time
     end
 
     if error && !action["NoRaise"]
@@ -545,7 +546,7 @@ class Device
 
     wait_time = (action["CheckTime"] ? action["CheckTime"] : @timeout)
 
-    while (Time.now - after_find) < wait_time
+    loop do
       begin
         @driver.action.move_to(el).pointer_down(:left).release.perform
         log_info("Time for click: #{Time.now - after_find}s") if action["CheckTime"]
@@ -553,6 +554,7 @@ class Device
       rescue => e
         error = e
       end
+      break if (Time.now - after_find) >= wait_time
     end
     if error && !action["NoRaise"]
       path = take_error_screenshot()
@@ -578,7 +580,7 @@ class Device
 
     wait_time = (action["CheckTime"] ? action["CheckTime"] : @timeout)
 
-    while (Time.now - after_find) < wait_time
+    loop do
       begin
         @platform == "iOS" ?
           @driver.action.move_to(el) :
@@ -593,6 +595,7 @@ class Device
       rescue => e
         error = e
       end
+      break if (Time.now - after_find) >= wait_time
     end
     if error && !action["NoRaise"]
       path = take_error_screenshot()

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -447,17 +447,17 @@ class Device
   #   OffsetFractionY
   #   NoRaise
   def click(action)
-    start = Time.now
+    before_find = Time.now
     el = wait_for(action)
     return unless el
 
-    now = Time.now
-    log_info("Time to find element: #{now - start}s") if action["CheckTime"]
+    after_find = Time.now
+    log_info("Time to find element: #{after_find - before_find}s") if action["CheckTime"]
     error = nil
 
     wait_time = (action["CheckTime"] ? action["CheckTime"] : @timeout)
 
-    while (Time.now - start) < wait_time
+    while (Time.now - after_find) < wait_time
       begin
         @platform == "iOS" ?
           @driver.action.move_to(el) :
@@ -478,7 +478,7 @@ class Device
         else
           el.click
         end
-        log_info("Time for click: #{Time.now - start}s") if action["CheckTime"]
+        log_info("Time for click: #{Time.now - after_find}s") if action["CheckTime"]
         return
       rescue => e
         error = e
@@ -535,20 +535,20 @@ class Device
   #   CheckTime
   #   NoRaise
   def press(action)
-    start = Time.now
+    before_find = Time.now
     el = wait_for(action)
     return unless el
 
-    now = Time.now
-    log_info("Time to find element: #{now - start}s") if action["CheckTime"]
+    after_find = Time.now
+    log_info("Time to find element: #{after_find - before_find}s") if action["CheckTime"]
     error = nil
 
     wait_time = (action["CheckTime"] ? action["CheckTime"] : @timeout)
 
-    while (Time.now - start) < wait_time
+    while (Time.now - after_find) < wait_time
       begin
         @driver.action.move_to(el).pointer_down(:left).release.perform
-        log_info("Time for click: #{Time.now - start}s") if action["CheckTime"]
+        log_info("Time for click: #{Time.now - after_find}s") if action["CheckTime"]
         return
       rescue => e
         error = e
@@ -568,17 +568,17 @@ class Device
   #   CheckTime
   #   NoRaise
   def click_and_hold(action)
-    start = Time.now
+    before_find = Time.now
     el = wait_for(action)
     return unless el
 
-    now = Time.now
-    log_info("Time to find element: #{now - start}s") if action["CheckTime"]
+    after_find = Time.now
+    log_info("Time to find element: #{after_find - before_find}s") if action["CheckTime"]
     error = nil
 
     wait_time = (action["CheckTime"] ? action["CheckTime"] : @timeout)
 
-    while (Time.now - start) < wait_time
+    while (Time.now - after_find) < wait_time
       begin
         @platform == "iOS" ?
           @driver.action.move_to(el) :
@@ -588,7 +588,7 @@ class Device
       end
       begin
         @driver.action.click_and_hold(el).perform
-        log_info("Time for click and hold: #{Time.now - start}s") if action["CheckTime"]
+        log_info("Time for click and hold: #{Time.now - after_find}s") if action["CheckTime"]
         return
       rescue => e
         error = e

--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -483,7 +483,7 @@ class Device
       rescue => e
         error = e
       end
-      break if (Time.now - after_find) >= wait_time
+      break if (Time.now - before_find) >= wait_time
     end
 
     if error && !action["NoRaise"]
@@ -554,7 +554,7 @@ class Device
       rescue => e
         error = e
       end
-      break if (Time.now - after_find) >= wait_time
+      break if (Time.now - before_find) >= wait_time
     end
     if error && !action["NoRaise"]
       path = take_error_screenshot()
@@ -595,7 +595,7 @@ class Device
       rescue => e
         error = e
       end
-      break if (Time.now - after_find) >= wait_time
+      break if (Time.now - before_find) >= wait_time
     end
     if error && !action["NoRaise"]
       path = take_error_screenshot()


### PR DESCRIPTION
This fixes a fairly specific issue with click actions (where multiple timestamps are generated while finding the element):

If the timeout for finding the element (`Time`) is specified to be longer than the timeout for clicking the element (`CheckTime` or the default timeout), there may be a situation where the element search does end up taking a long time - longer than the timeout for clicking the element. This would mean that the condition `while (Time.now - start) < wait_time` would immediately fail, the click action would not even be attempted, and the test would continue.

This PR fixes the issue by adjusting the above condition.