### PR TITLE
fix: update close_app implementation

### DIFF
--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -243,8 +243,8 @@ class Device
   end
 
   # closes the currently opened app and puts it in the background
-  def close_app(action = nil)
-    @driver.background_app(-1)
+  def close_app(_action)
+    @driver.execute_script('mobile: backgroundApp', {'seconds': -1})
   end
 
   # launches the app specified by the Android app package / iOS bundle ID


### PR DESCRIPTION
The current implementation for `close_app` is deprecated. This PR updates it to the latest syntax using execute methods, and removes the deprecation warning.